### PR TITLE
Remove obsolete method form `root.did`

### DIFF
--- a/public/data/interfaces/nns/root.did
+++ b/public/data/interfaces/nns/root.did
@@ -32,5 +32,4 @@ service : {
   submit_change_nns_canister_proposal : (nat64, ChangeNnsCanisterProposalPayload) -> (Result_ProposalId_String);
   canister_status : (CanisterIdRecord) -> (CanisterStatusResult);
   change_nns_canister : (ChangeNnsCanisterProposalPayload) -> ();
-  add_nns_canister : (AddNnsCanisterProposalPayload) -> ();
 }


### PR DESCRIPTION
Sorry this is my fault. I have grepped for the type `AddNnsCanisterProposalPayload` in the web editor before removing, but somehow I missed it. #6 made the `.did` badly formed.

Now it can call out again:
<img width="999" alt="Screenshot 2021-06-16 at 14 10 08" src="https://user-images.githubusercontent.com/1312006/122216418-ad2c7200-ceac-11eb-92c3-d73996b1f209.png">

(The resulting error is expected.)